### PR TITLE
chore: change tmpHarvest url

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring:
 fuseki:
   unionGraphUri: ${FDK_FUSEKI_SERVICE_URI:http://fdk-fuseki-service:8080/fuseki}/harvested?graph=https://services.fellesdatakatalog.digdir.no
 application:
-  tmpHarvest: ${TMP_HARVEST:https://gist.githubusercontent.com/stigbd/17ad84a3ae2a6702ec303e36dfd495ab/raw/51fecb7b4d5bc5f6bc02348bf1fffab734639c41/fdk-public-service-publisher.ttl}
+  tmpHarvest: ${TMP_HARVEST:https://raw.githubusercontent.com/Informasjonsforvaltning/fdk-testdata/master/testdata/fdk-public-service-publisher.ttl}
   publicServiceHarvesterUri: ${FDK_BASE_URI:https://staging.fellesdatakatalog.digdir.no}/public-services
   harvestAdminRootUrl: ${HARVEST_ADMIN_ROOT_URL:http://fdk-harvest-admin:8080/api}
 
@@ -32,7 +32,7 @@ spring:
 fuseki:
   unionGraphUri: http://localhost:3030/fuseki/harvested?graph=https://services.fellesdatakatalog.digdir.no
 application:
-  tmpHarvest: https://gist.githubusercontent.com/stigbd/17ad84a3ae2a6702ec303e36dfd495ab/raw/51fecb7b4d5bc5f6bc02348bf1fffab734639c41/fdk-public-service-publisher.ttl
+  tmpHarvest: https://raw.githubusercontent.com/Informasjonsforvaltning/fdk-testdata/master/testdata/fdk-public-service-publisher.ttl
   publicServiceHarvesterUri: https://staging.fellesdatakatalog.digdir.no/public-services
   harvestAdminRootUrl: https://admin-api.staging.fellesdatakatalog.digdir.no/api
 


### PR DESCRIPTION
Endepunktet det skal høstes fra er flyttet til https://raw.githubusercontent.com/Informasjonsforvaltning/fdk-testdata/master/testdata/fdk-public-service-publisher.ttl